### PR TITLE
add code fencing to html tags so page renders correctly

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -17,8 +17,8 @@ screen sizes, and much more!
 CSS can be added to HTML documents in 3 ways:
 
 * *Inline*: by using the style attribute inside HTML elements.
-* *Internal*: by using a <style> element in the <head> section.
-* *External*: by using a <link> element to link to an external CSS file.
+* *Internal*: by using a `<style>` element in the `<head>` section.
+* *External*: by using a `<link>` element to link to an external CSS file.
 
 The most common way to add CSS, is to keep the styles in external CSS files.
 


### PR DESCRIPTION
Missing code fencing (or some other form of escape) for HTML tags is causing the document to prematurely terminate on or about line 20 of css.md

This PR adds inline code fencing on two lines in css.md to correct the issue.

Basic local testing of the changes was conducted prior to submission of this PR.