### PR TITLE
docs: add additional references for Python gettext and locale docs

### DIFF
--- a/docs/python_internationalization.md
+++ b/docs/python_internationalization.md
@@ -35,3 +35,6 @@ help extract and generate message catalogs from the source code.
 
 * [Phrase blog on Localizing with GNU gettext](https://phrase.com/blog/posts/translate-python-gnu-gettext/)
 * [Phrase blog on internationalization](https://phrase.com/lp/i18n-manager/)
+* [Python `gettext` documentation](https://docs.python.org/3/library/gettext.html)
+* [Python `locale` documentation](https://docs.python.org/3/library/locale.html)
+* [GNU gettext manual](https://www.gnu.org/software/gettext/manual/gettext.html)


### PR DESCRIPTION
[W3C](https://www.w3.org/International/i18n-drafts/nav/about) also contains a wealth of content regarding internationalization. Since your focus here is primarily on Python, I didn't include it.

/cc @lyz-code