### PR TITLE
fix: replace broken awesome-prometheus-alerts link

### DIFF
--- a/docs/devops/prometheus/alertmanager.md
+++ b/docs/devops/prometheus/alertmanager.md
@@ -357,7 +357,7 @@ If that doesn't work for you, you can use the [sleep peacefully guidelines](http
 
 Alert rules are a special kind of Prometheus Rules that trigger alerts based on
 PromQL expressions. People have gathered several examples under [Awesome
-prometheus alert rules](https://awesome-prometheus-alerts.grep.to/rules)
+prometheus alert rules](https://samber.github.io/awesome-prometheus-alerts/rules)
 
 Alerts must be configured in the Prometheus configuration, either through the [operator](prometheus_operator.md)
 helm chart, under the `additionalPrometheusRulesMap` or in the `prometheus.yml` file. For example:
@@ -399,4 +399,4 @@ To silence an alert with a regular expression use the matcher
 
 - [Source](https://github.com/prometheus/alertmanager)
 - [Docs](https://prometheus.io/docs/alerting/latest/alertmanager/
-- [Awesome prometheus alert rules](https://awesome-prometheus-alerts.grep.to/rules)
+- [Awesome prometheus alert rules](https://samber.github.io/awesome-prometheus-alerts/rules)

--- a/docs/devops/prometheus/blackbox_exporter.md
+++ b/docs/devops/prometheus/blackbox_exporter.md
@@ -357,7 +357,7 @@ ping:
 
 Now that we've got the metrics, we can define the [alert
 rules](alertmanager.md#alert-rules). Most have been tweaked from the [Awesome
-prometheus alert rules](https://awesome-prometheus-alerts.grep.to/rules)
+prometheus alert rules](https://samber.github.io/awesome-prometheus-alerts/rules)
 collection.
 
 To make security tests

--- a/docs/devops/prometheus/node_exporter.md
+++ b/docs/devops/prometheus/node_exporter.md
@@ -125,11 +125,11 @@ Once the instance metrics are being ingested, we can do a periodic
 [analysis](instance_sizing_analysis.md) to deduce which instances are undersized
 or oversized.
 
-# [Node exporter alerts](https://awesome-prometheus-alerts.grep.to/rules)
+# [Node exporter alerts](https://samber.github.io/awesome-prometheus-alerts/rules)
 
 Now that we've got the metrics, we can define the [alert
 rules](alertmanager.md#alert-rules). Most have been tweaked from the [Awesome
-prometheus alert rules](https://awesome-prometheus-alerts.grep.to/rules)
+prometheus alert rules](https://samber.github.io/awesome-prometheus-alerts/rules)
 collection.
 
 ## Host out of memory
@@ -669,4 +669,4 @@ The metrics will show `node_reboot_required 1` when a reboot is required and `no
 
 - [Git](https://github.com/prometheus/node_exporter)
 - [Prometheus node exporter guide](https://prometheus.io/docs/guides/node-exporter/)
-- [Node exporter alerts](https://awesome-prometheus-alerts.grep.to/rules)
+- [Node exporter alerts](https://samber.github.io/awesome-prometheus-alerts/rules)

--- a/docs/elasticsearch_exporter.md
+++ b/docs/elasticsearch_exporter.md
@@ -113,7 +113,7 @@ helmfile apply
 
 Now that we've got the metrics, we can define the [alert
 rules](alertmanager.md#alert-rules). Most have been tweaked from the [Awesome
-prometheus alert rules](https://awesome-prometheus-alerts.grep.to/rules)
+prometheus alert rules](https://samber.github.io/awesome-prometheus-alerts/rules)
 collection.
 
 ## Availability alerts


### PR DESCRIPTION
Hi!

The `awesome-prometheus-alerts.grep.to` domain is no longer maintained: the site is gone and the domain now shows a parking page, so the link in this repo is broken.

This PR replaces it with the current home of the project:

https://samber.github.io/awesome-prometheus-alerts

No other changes. Thanks!
